### PR TITLE
Add execution time for each line / root method

### DIFF
--- a/src/main/java/org/sahagin/report/HtmlReport.java
+++ b/src/main/java/org/sahagin/report/HtmlReport.java
@@ -611,23 +611,27 @@ public class HtmlReport {
     }
 
     private void addExecutionTime(RootMethodRunResult runResult, List<ReportCodeLine> reportCodeBody) {
-        Map<Integer, Integer> executionTimeMap = new HashMap<Integer, Integer>();
+        Map<String, Integer> executionTimeMap = new HashMap<String, Integer>();
         for (LineScreenCapture lineScreenCapture : runResult.getLineScreenCaptures()) {
             for (StackLine stackLine : lineScreenCapture.getStackLines()) {
-                executionTimeMap.put(stackLine.getLine(), stackLine.getExecutionTime());
+                executionTimeMap.put(createMethodLineKey(stackLine), stackLine.getExecutionTime());
             }
         }
 
         for (ReportCodeLine reportCodeLine : reportCodeBody) {
             int executionTime = 0;
             if (reportCodeLine.getStackLines().size() != 0) {
-                int key = reportCodeLine.getStackLines().get(0).getLine();
+                String key = createMethodLineKey(reportCodeLine.getStackLines().get(0));
                 if (executionTimeMap.containsKey(key)) {
                     executionTime += executionTimeMap.get(key);
                     reportCodeLine.setExecutionTime(executionTime);
                 }
             }
         }
+    }
+
+    private String createMethodLineKey(StackLine stackLine) {
+        return String.format("%s_%d", stackLine.getMethodKey(), stackLine.getLine());
     }
 
     private void generateVelocityOutput(

--- a/src/main/java/org/sahagin/report/HtmlReport.java
+++ b/src/main/java/org/sahagin/report/HtmlReport.java
@@ -617,24 +617,6 @@ public class HtmlReport {
         }
     }
 
-//    private void addExecutionTime(RootMethodRunResult runResult, List<ReportCodeLine> reportCodeBody) {
-//        Map<String, Integer> executionTimeMap = new HashMap<String, Integer>();
-//        for (LineScreenCapture lineScreenCapture : runResult.getLineScreenCaptures()) {
-//            executionTimeMap.put(createMethodLineKey(stackLine), lineScreenCapture.getExecutionTime());
-//        }
-//
-//        for (ReportCodeLine reportCodeLine : reportCodeBody) {
-//            int executionTime = 0;
-//            if (reportCodeLine.getStackLines().size() != 0) {
-//                String key = createMethodLineKey(reportCodeLine.getStackLines().get(0));
-//                if (executionTimeMap.containsKey(key)) {
-//                    executionTime += executionTimeMap.get(key);
-//                    reportCodeLine.setExecutionTime(executionTime);
-//                }
-//            }
-//        }
-//    }
-
     private String createMethodLineKey(StackLine stackLine) {
         return String.format("%s_%d", stackLine.getMethodKey(), stackLine.getLine());
     }

--- a/src/main/java/org/sahagin/report/ReportCodeLine.java
+++ b/src/main/java/org/sahagin/report/ReportCodeLine.java
@@ -24,6 +24,7 @@ public class ReportCodeLine {
     private String parentTtId = null; // null means no parent
     private String imageId;
     private boolean childLoaded = false;
+    private int executionTime;
 
     public String getMethodKey() {
         if (!(codeLine.getCode() instanceof SubMethodInvoke)) {
@@ -137,6 +138,14 @@ public class ReportCodeLine {
 
     public void setChildLoaded(boolean childLoaded) {
         this.childLoaded = childLoaded;
+    }
+
+    public int getExecutionTime() {
+        return executionTime;
+    }
+
+    public void setExecutionTime(int executionTime) {
+        this.executionTime = executionTime;
     }
 
 }

--- a/src/main/java/org/sahagin/report/ReportCodeLine.java
+++ b/src/main/java/org/sahagin/report/ReportCodeLine.java
@@ -24,7 +24,7 @@ public class ReportCodeLine {
     private String parentTtId = null; // null means no parent
     private String imageId;
     private boolean childLoaded = false;
-    private int executionTime;
+    private int executionTime = -1;
 
     public String getMethodKey() {
         if (!(codeLine.getCode() instanceof SubMethodInvoke)) {

--- a/src/main/java/org/sahagin/report/ReportScreenCapture.java
+++ b/src/main/java/org/sahagin/report/ReportScreenCapture.java
@@ -19,6 +19,7 @@ public class ReportScreenCapture {
     private String imageId;
     private int imageWidth;
     private int imageHeight;
+    private int executionTime;
 
     public String getPath() {
         return path;
@@ -50,6 +51,14 @@ public class ReportScreenCapture {
 
     public void setImageHeight(int imageHeight) {
         this.imageHeight = imageHeight;
+    }
+
+    public int getExecutionTime() {
+        return executionTime;
+    }
+
+    public void setExecutionTime(int executionTime) {
+        this.executionTime = executionTime;
     }
 
     public void setImageSizeFromImageFile(File file) {

--- a/src/main/java/org/sahagin/share/runresults/LineScreenCapture.java
+++ b/src/main/java/org/sahagin/share/runresults/LineScreenCapture.java
@@ -15,6 +15,7 @@ public class LineScreenCapture implements YamlConvertible {
     private File path;
     // head element means stack top
     private List<StackLine> stackLines = new ArrayList<StackLine>(16);
+    private int executionTime;
 
     public File getPath() {
         return path;
@@ -36,6 +37,14 @@ public class LineScreenCapture implements YamlConvertible {
         for (StackLine stackLine : stackLines) {
             addStackLine(stackLine);
         }
+    }
+
+    public int getExecutionTime() {
+        return executionTime;
+    }
+
+    public void setExecutionTime(int executionTime) {
+        this.executionTime = executionTime;
     }
 
     // check if stack line for this instance matches targetStackLines
@@ -61,6 +70,7 @@ public class LineScreenCapture implements YamlConvertible {
         Map<String, Object> result = new HashMap<String, Object>(2);
         result.put("path", path.getPath());
         result.put("stackLines", YamlUtils.toYamlObjectList(stackLines));
+        result.put("executionTime", executionTime);
         return result;
     }
 
@@ -68,6 +78,7 @@ public class LineScreenCapture implements YamlConvertible {
     public void fromYamlObject(Map<String, Object> yamlObject)
             throws YamlConvertException {
         path = new File(YamlUtils.getStrValue(yamlObject, "path"));
+        executionTime = YamlUtils.getIntValue(yamlObject, "executionTime");
         List<Map<String, Object>> stackLinesYamlObj
         = YamlUtils.getYamlObjectListValue(yamlObject, "stackLines");
         stackLines = new ArrayList<StackLine>(stackLinesYamlObj.size());

--- a/src/main/java/org/sahagin/share/runresults/RootMethodRunResult.java
+++ b/src/main/java/org/sahagin/share/runresults/RootMethodRunResult.java
@@ -19,6 +19,7 @@ public class RootMethodRunResult implements YamlConvertible {
     private TestMethod rootMethod;
     private List<RunFailure> runFailures = new ArrayList<RunFailure>(16);
     private List<LineScreenCapture> lineScreenCaptures = new ArrayList<LineScreenCapture>(32);
+    private int executionTime;
 
     public String getRootMethodKey() {
         return rootMethodKey;
@@ -52,6 +53,14 @@ public class RootMethodRunResult implements YamlConvertible {
         this.lineScreenCaptures.add(lineScreenCapture);
     }
 
+    public void setExecutionTime(int executionTime) {
+        this.executionTime = executionTime;
+    }
+
+    public int getExecutionTime() {
+        return executionTime;
+    }
+
     @Override
     public Map<String, Object> toYamlObject() {
         Map<String, Object> result = new HashMap<String, Object>(4);
@@ -63,6 +72,7 @@ public class RootMethodRunResult implements YamlConvertible {
         if (!lineScreenCaptures.isEmpty()) {
             result.put("lineScreenCaptures", YamlUtils.toYamlObjectList(lineScreenCaptures));
         }
+        result.put("executionTime", executionTime);
         return result;
     }
 
@@ -93,6 +103,7 @@ public class RootMethodRunResult implements YamlConvertible {
             lineScreenCapture.fromYamlObject(lineScreenCaptureYamlObj);
             lineScreenCaptures.add(lineScreenCapture);
         }
+        executionTime = YamlUtils.getIntValue(yamlObject, "executionTime");
     }
 
 }

--- a/src/main/java/org/sahagin/share/runresults/StackLine.java
+++ b/src/main/java/org/sahagin/share/runresults/StackLine.java
@@ -14,7 +14,6 @@ public class StackLine implements YamlConvertible {
     private TestMethod method;
     private int line;
     private int codeBodyIndex;
-    private int executionTime = 0;
 
     // normal constructor
     public StackLine() {
@@ -61,21 +60,12 @@ public class StackLine implements YamlConvertible {
         this.codeBodyIndex = codeBodyIndex;
     }
 
-    public int getExecutionTime() {
-        return executionTime;
-    }
-
-    public void setExecutionTime(int executionTime) {
-        this.executionTime = executionTime;
-    }
-
     @Override
     public Map<String, Object> toYamlObject() {
         Map<String, Object> result = new HashMap<String, Object>(8);
         result.put("methodKey", methodKey);
         result.put("codeBodyIndex", codeBodyIndex);
         result.put("line", line);
-        result.put("executionTime", executionTime);
         return result;
     }
 
@@ -85,7 +75,6 @@ public class StackLine implements YamlConvertible {
         method = null;
         codeBodyIndex = YamlUtils.getIntValue(yamlObject, "codeBodyIndex");
         line = YamlUtils.getIntValue(yamlObject, "line");
-        executionTime = YamlUtils.getIntValue(yamlObject, "executionTime");
     }
 
 }

--- a/src/main/java/org/sahagin/share/runresults/StackLine.java
+++ b/src/main/java/org/sahagin/share/runresults/StackLine.java
@@ -14,6 +14,7 @@ public class StackLine implements YamlConvertible {
     private TestMethod method;
     private int line;
     private int codeBodyIndex;
+    private int executionTime = 0;
 
     // normal constructor
     public StackLine() {
@@ -60,12 +61,21 @@ public class StackLine implements YamlConvertible {
         this.codeBodyIndex = codeBodyIndex;
     }
 
+    public int getExecutionTime() {
+        return executionTime;
+    }
+
+    public void setExecutionTime(int executionTime) {
+        this.executionTime = executionTime;
+    }
+
     @Override
     public Map<String, Object> toYamlObject() {
         Map<String, Object> result = new HashMap<String, Object>(8);
         result.put("methodKey", methodKey);
         result.put("codeBodyIndex", codeBodyIndex);
         result.put("line", line);
+        result.put("executionTime", executionTime);
         return result;
     }
 
@@ -75,6 +85,7 @@ public class StackLine implements YamlConvertible {
         method = null;
         codeBodyIndex = YamlUtils.getIntValue(yamlObject, "codeBodyIndex");
         line = YamlUtils.getIntValue(yamlObject, "line");
+        executionTime = YamlUtils.getIntValue(yamlObject, "executionTime");
     }
 
 }

--- a/src/main/resources/css/report.css
+++ b/src/main/resources/css/report.css
@@ -121,3 +121,7 @@ body {
 #localeData {
   display: none;
 }
+
+.numeric_cell {
+  text-align: right;
+}

--- a/src/main/resources/js/report/report.js
+++ b/src/main/resources/js/report/report.js
@@ -491,7 +491,7 @@ function loadCodeBodyHiddenNode(tr) {
     
     childNodeHtml = childNodeHtml + sahagin.CommonUtils.strFormat(
       '<tr data-tt-id="{0}" data-tt-parent-id="{1}" data-image-id="{0}" data-method-key="{2}" class="{3}">'
-          + '<td>{4}</td><td>{5}</td><td class="srcInfo">{6}</td></tr>',
+          + '<td>{4}</td><td>{5}</td><td class="srcInfo">{6}</td><td class="srcInfo"></td></tr>',
       ttId, parentTtId, methodKey, lineClass, pageDoc, testDoc, original);
     
     var methodArgTestDocs = sahagin.TestDocResolver.placeholderResolvedMethodArgTestDocs(

--- a/src/main/resources/js/report/report.js
+++ b/src/main/resources/js/report/report.js
@@ -488,11 +488,17 @@ function loadCodeBodyHiddenNode(tr) {
       testDoc = '- ' + $("#codeLineWithoutTestDoc").text() + ' -';
     }
     var original = codeLine.getCode().getOriginal();
+    var executionTime = $("div[data-image-id='" + ttId + "']").attr("execution-time")
+    if (executionTime == undefined) {
+        executionTime = "";
+    } else {
+        executionTime = executionTime + " ms";
+    }
     
     childNodeHtml = childNodeHtml + sahagin.CommonUtils.strFormat(
       '<tr data-tt-id="{0}" data-tt-parent-id="{1}" data-image-id="{0}" data-method-key="{2}" class="{3}">'
-          + '<td>{4}</td><td>{5}</td><td class="srcInfo">{6}</td><td class="srcInfo"></td></tr>',
-      ttId, parentTtId, methodKey, lineClass, pageDoc, testDoc, original);
+          + '<td>{4}</td><td>{5}</td><td class="srcInfo">{6}</td><td class="srcInfo numeric_cell">{7}</td></tr>',
+      ttId, parentTtId, methodKey, lineClass, pageDoc, testDoc, original, executionTime);
     
     var methodArgTestDocs = sahagin.TestDocResolver.placeholderResolvedMethodArgTestDocs(
         codeLine.getCode(), parentMethodArgTestDocs);

--- a/src/main/resources/template/report.html.vm
+++ b/src/main/resources/template/report.html.vm
@@ -98,8 +98,8 @@
                 <tr data-tt-id="${codeLine.getTtId()}" ${dataTtParentId} data-image-id="${codeLine.getImageId()}" data-method-key="${codeLine.getMethodKey()}" class="${lineClass} ${loadedClass}">
                   <td>${codeLine.getPageDoc()}</td>
                   <td>${codeLine.getTestDoc()}</td>
-                  <td class="numeric_cell">$executionTime</td>
                   <td class="srcInfo">${codeLine.getCodeLine().getCode().getOriginal()}</td>
+                  <td class="srcInfo numeric_cell">$executionTime</td>
                 </tr>
                 #end
               </tbody>

--- a/src/main/resources/template/report.html.vm
+++ b/src/main/resources/template/report.html.vm
@@ -59,7 +59,7 @@
       #if ( ${executionTime} )
       <div>${executionTime} ms</div>
       #else
-      <div>${executionTime}</div>
+      <div></div>
       #end
     </header>
     <div id="main_container">
@@ -122,7 +122,7 @@
         <ul class="bxslider">
           #foreach( $capture in $captures )
           <li>
-            <div data-image-id="${capture.getImageId()}" data-image-width="${capture.getImageWidth()}" data-image-height="${capture.getImageHeight()}" class="scrollContainer">
+            <div data-image-id="${capture.getImageId()}" data-image-width="${capture.getImageWidth()}" data-image-height="${capture.getImageHeight()}" execution-time="${capture.getExecutionTime()}" class="scrollContainer">
               <img src="${capture.getPath()}" />
             </div>
           </li>

--- a/src/main/resources/template/report.html.vm
+++ b/src/main/resources/template/report.html.vm
@@ -56,6 +56,11 @@
       #else
       <div>${methodName}</div>
       #end
+      #if ( ${executionTime} )
+      <div>${executionTime} ms</div>
+      #else
+      <div>${executionTime}</div>
+      #end
     </header>
     <div id="main_container">
       <div id="button_container">
@@ -85,9 +90,15 @@
                 #else
                   #set( $loadedClass = "" )
                 #end
+                #if( ${codeLine.getExecutionTime()} >= 0 )
+                  #set( $executionTime = ${codeLine.getExecutionTime()} + " ms" )
+                #else
+                  #set( $executionTime = "" )
+                #end
                 <tr data-tt-id="${codeLine.getTtId()}" ${dataTtParentId} data-image-id="${codeLine.getImageId()}" data-method-key="${codeLine.getMethodKey()}" class="${lineClass} ${loadedClass}">
                   <td>${codeLine.getPageDoc()}</td>
                   <td>${codeLine.getTestDoc()}</td>
+                  <td class="numeric_cell">$executionTime</td>
                   <td class="srcInfo">${codeLine.getCodeLine().getCode().getOriginal()}</td>
                 </tr>
                 #end

--- a/src/test/resources/org/sahagin/report/HtmlReportTestRes/reportGenerateShouldSucceedWithoutError/input/runResults/sample.SampleTest/shouldFail
+++ b/src/test/resources/org/sahagin/report/HtmlReportTestRes/reportGenerateShouldSucceedWithoutError/input/runResults/sample.SampleTest/shouldFail
@@ -1,11 +1,12 @@
 runFailures:
 - message: err
   stackLines:
-  - {codeBodyIndex: 0, methodKey: sample.SampleTest.shouldFail-void, line: 29}
+  - {codeBodyIndex: 0, methodKey: sample.SampleTest.shouldFail-void, line: 29, executionTime: 50}
   stackTrace: "err"
 lineScreenCaptures:
 - path: ${inputCaptureRootDirForSahaginInternalTest}/001.png
   stackLines:
-  - {codeBodyIndex: 0, methodKey: sample.SampleTest.shouldFail-void, line: 29}
+  - {codeBodyIndex: 0, methodKey: sample.SampleTest.shouldFail-void, line: 29, executionTime: 50}
 formatVersion: "*"
 rootMethodKey: sample.SampleTest.shouldFail-void
+executionTime: 100

--- a/src/test/resources/org/sahagin/report/HtmlReportTestRes/reportGenerateShouldSucceedWithoutError/input/runResults/sample.SampleTest/shouldFail
+++ b/src/test/resources/org/sahagin/report/HtmlReportTestRes/reportGenerateShouldSucceedWithoutError/input/runResults/sample.SampleTest/shouldFail
@@ -1,12 +1,13 @@
 runFailures:
 - message: err
   stackLines:
-  - {codeBodyIndex: 0, methodKey: sample.SampleTest.shouldFail-void, line: 29, executionTime: 50}
+  - {codeBodyIndex: 0, methodKey: sample.SampleTest.shouldFail-void, line: 29}
   stackTrace: "err"
 lineScreenCaptures:
-- path: ${inputCaptureRootDirForSahaginInternalTest}/001.png
+- executionTime: 50
+  path: ${inputCaptureRootDirForSahaginInternalTest}/001.png
   stackLines:
-  - {codeBodyIndex: 0, methodKey: sample.SampleTest.shouldFail-void, line: 29, executionTime: 50}
+  - {codeBodyIndex: 0, methodKey: sample.SampleTest.shouldFail-void, line: 29}
 formatVersion: "*"
 rootMethodKey: sample.SampleTest.shouldFail-void
 executionTime: 100

--- a/src/test/resources/org/sahagin/report/HtmlReportTestRes/reportGenerateShouldSucceedWithoutError/input/runResults/sample.SampleTest/shouldSucceed
+++ b/src/test/resources/org/sahagin/report/HtmlReportTestRes/reportGenerateShouldSucceedWithoutError/input/runResults/sample.SampleTest/shouldSucceed
@@ -1,8 +1,9 @@
 runFailures: []
 lineScreenCaptures:
-- path: ${inputCaptureRootDirForSahaginInternalTest}/001.png
+- executionTime: 50
+  path: ${inputCaptureRootDirForSahaginInternalTest}/001.png
   stackLines:
-  - {codeBodyIndex: 0, methodKey: sample.SampleTest.shouldSucceed-void, line: 24, executionTime: 50}
+  - {codeBodyIndex: 0, methodKey: sample.SampleTest.shouldSucceed-void, line: 24}
 formatVersion: "*"
 rootMethodKey: sample.SampleTest.shouldSucceed-void
 executionTime: 100

--- a/src/test/resources/org/sahagin/report/HtmlReportTestRes/reportGenerateShouldSucceedWithoutError/input/runResults/sample.SampleTest/shouldSucceed
+++ b/src/test/resources/org/sahagin/report/HtmlReportTestRes/reportGenerateShouldSucceedWithoutError/input/runResults/sample.SampleTest/shouldSucceed
@@ -2,6 +2,7 @@ runFailures: []
 lineScreenCaptures:
 - path: ${inputCaptureRootDirForSahaginInternalTest}/001.png
   stackLines:
-  - {codeBodyIndex: 0, methodKey: sample.SampleTest.shouldSucceed-void, line: 24}
+  - {codeBodyIndex: 0, methodKey: sample.SampleTest.shouldSucceed-void, line: 24, executionTime: 50}
 formatVersion: "*"
 rootMethodKey: sample.SampleTest.shouldSucceed-void
+executionTime: 100

--- a/src/test/resources/org/sahagin/share/runresults/RootMethodRunResultTestRes/yamlConversion/rootMethodRunResult
+++ b/src/test/resources/org/sahagin/share/runresults/RootMethodRunResultTestRes/yamlConversion/rootMethodRunResult
@@ -1,7 +1,7 @@
 runFailures:
 - message: 'java.lang.AssertionError: expected:<1> but was:<2>'
   stackLines:
-  - {executionTime: 10, line: 91, codeBodyIndex: 1, methodKey: Lorg/sahagin/runlib/runresultsgen/RunResultGenerateHookTestRes/test/TestMain;.noTestDocMethodFailTest()V}
+  - {line: 91, codeBodyIndex: 1, methodKey: Lorg/sahagin/runlib/runresultsgen/RunResultGenerateHookTestRes/test/TestMain;.noTestDocMethodFailTest()V}
   stackTrace: "java.lang.AssertionError: expected:<1> but was:<2>\n\tat org.junit.Assert.fail(Assert.java:88)\n\
     \tat org.junit.Assert.failNotEquals(Assert.java:743)\n\tat org.junit.Assert.assertEquals(Assert.java:118)\n\
     \tat org.junit.Assert.assertEquals(Assert.java:555)\n\tat org.junit.Assert.assertEquals(Assert.java:542)\n\
@@ -29,7 +29,8 @@ runFailures:
 formatVersion: "*"
 rootMethodKey: Lorg/sahagin/runlib/runresultsgen/RunResultGenerateHookTestRes/test/TestMain;.noTestDocMethodFailTest()V
 lineScreenCaptures:
-- path: 001.png
+- executionTime: 5
+  path: 001.png
   stackLines:
-  - {executionTime: 5, line: 91, codeBodyIndex: 1, methodKey: Lorg/sahagin/runlib/runresultsgen/RunResultGenerateHookTestRes/test/TestMain;.noTestDocMethodFailTest()V}
+  - {line: 91, codeBodyIndex: 1, methodKey: Lorg/sahagin/runlib/runresultsgen/RunResultGenerateHookTestRes/test/TestMain;.noTestDocMethodFailTest()V}
 executionTime: 1500

--- a/src/test/resources/org/sahagin/share/runresults/RootMethodRunResultTestRes/yamlConversion/rootMethodRunResult
+++ b/src/test/resources/org/sahagin/share/runresults/RootMethodRunResultTestRes/yamlConversion/rootMethodRunResult
@@ -1,7 +1,7 @@
 runFailures:
 - message: 'java.lang.AssertionError: expected:<1> but was:<2>'
   stackLines:
-  - {line: 91, codeBodyIndex: 1, methodKey: Lorg/sahagin/runlib/runresultsgen/RunResultGenerateHookTestRes/test/TestMain;.noTestDocMethodFailTest()V}
+  - {executionTime: 10, line: 91, codeBodyIndex: 1, methodKey: Lorg/sahagin/runlib/runresultsgen/RunResultGenerateHookTestRes/test/TestMain;.noTestDocMethodFailTest()V}
   stackTrace: "java.lang.AssertionError: expected:<1> but was:<2>\n\tat org.junit.Assert.fail(Assert.java:88)\n\
     \tat org.junit.Assert.failNotEquals(Assert.java:743)\n\tat org.junit.Assert.assertEquals(Assert.java:118)\n\
     \tat org.junit.Assert.assertEquals(Assert.java:555)\n\tat org.junit.Assert.assertEquals(Assert.java:542)\n\
@@ -31,4 +31,5 @@ rootMethodKey: Lorg/sahagin/runlib/runresultsgen/RunResultGenerateHookTestRes/te
 lineScreenCaptures:
 - path: 001.png
   stackLines:
-  - {line: 91, codeBodyIndex: 1, methodKey: Lorg/sahagin/runlib/runresultsgen/RunResultGenerateHookTestRes/test/TestMain;.noTestDocMethodFailTest()V}
+  - {executionTime: 5, line: 91, codeBodyIndex: 1, methodKey: Lorg/sahagin/runlib/runresultsgen/RunResultGenerateHookTestRes/test/TestMain;.noTestDocMethodFailTest()V}
+executionTime: 1500


### PR DESCRIPTION
I added executionTime field to StackLine and RootMethodRunResult
so as to display execution time for whole method and each code line in test class in the report.
Execution time is measured in HookMethod Manager using system time.

Although some test data is modified to this function,
I didn't add / modify any test method.
